### PR TITLE
Remove string to char* warnings

### DIFF
--- a/c-bindings/pruss.h
+++ b/c-bindings/pruss.h
@@ -40,7 +40,6 @@ struct PRUSS{
     PRU pru1;
 };
 
-void test(PRU*);
 void PRUSS_init(PRUSS *pruss);
 int PRUSS_bootUp(PRUSS *pruss);
 void PRUSS_dest(PRUSS *pruss);

--- a/examples/rpmsg_echo.cpp
+++ b/examples/rpmsg_echo.cpp
@@ -6,18 +6,18 @@ using namespace std;
 int main()
 {
 	PRUSS& p = PRUSS::get();
-	PRU p0 = p.pru0;
-	p0.enable();
-	if(!p0.load("./firmware_examples/rpmsg_echo/gen/rpmsg_echo.out"))
+	PRU p1 = p.pru1;
+	p1.enable();
+	/*if(!p0.load("./firmware_examples/rpmsg_echo/gen/rpmsg_echo.out"))
 		cout << "Firmware loaded\n";
 	else
-		return -1;
+		return -1;*/
 	string s;
 	cout << "Enter a message: ";
 	getline(cin, s);
-	p0.sendMsg(s);
-	cout << "Loopback       : "<< p0.getMsg();
-	p0.disable();
+	p1.sendMsg(s);
+	cout << "Loopback       : "<< p1.getMsg();
+	p1.disable();
 	p.shutDown();
 
 }

--- a/examples/userspace.py
+++ b/examples/userspace.py
@@ -1,0 +1,14 @@
+import pruss
+from pruss import *
+
+pss = PRUSS.get()
+p1 = pss.pru1
+p1.enable()
+
+s = input("Enter a string to send to rpmsg_pru31 \n")
+p1.sendMsg(s)
+
+print("Message received: ")
+print (p1.getMsg())
+p1.disable()
+pss.shutDown()


### PR DESCRIPTION
string to char* warnings removed in c-bindings
test function was still present in the library
simple python userspace program added (Objective was to study how to use python using swig cpp wrappers)