### PR TITLE
Add PRU Cookbook's PWM example 

### DIFF
--- a/examples/firmware_examples/example3-pwm/AM335x_PRU.cmd
+++ b/examples/firmware_examples/example3-pwm/AM335x_PRU.cmd
@@ -1,0 +1,86 @@
+/****************************************************************************/
+/*  AM335x_PRU.cmd                                                          */
+/*  Copyright (c) 2015  Texas Instruments Incorporated                      */
+/*                                                                          */
+/*    Description: This file is a linker command file that can be used for  */
+/*                 linking PRU programs built with the C compiler and       */
+/*                 the resulting .out file on an AM335x device.             */
+/****************************************************************************/
+
+-cr								/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	PRU_IMEM		: org = 0x00000000 len = 0x00002000  /* 8kB PRU0 Instruction RAM */
+
+      PAGE 1:
+
+	/* RAM */
+
+	PRU_DMEM_0_1	: org = 0x00000000 len = 0x00002000 CREGISTER=24 /* 8kB PRU Data RAM 0_1 */
+	PRU_DMEM_1_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25 /* 8kB PRU Data RAM 1_0 */
+
+	  PAGE 2:
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00003000 CREGISTER=28 /* 12kB Shared RAM */
+
+	DDR			    : org = 0x80000000 len = 0x00000100	CREGISTER=31
+	L3OCMC			: org = 0x40000000 len = 0x00010000	CREGISTER=30
+
+
+	/* Peripherals */
+
+	PRU_CFG			: org = 0x00026000 len = 0x00000044	CREGISTER=4
+	PRU_ECAP		: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_IEP			: org = 0x0002E000 len = 0x0000031C	CREGISTER=26
+	PRU_INTC		: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_UART		: org = 0x00028000 len = 0x00000038	CREGISTER=7
+
+	DCAN0			: org = 0x481CC000 len = 0x000001E8	CREGISTER=14
+	DCAN1			: org = 0x481D0000 len = 0x000001E8	CREGISTER=15
+	DMTIMER2		: org = 0x48040000 len = 0x0000005C	CREGISTER=1
+	PWMSS0			: org = 0x48300000 len = 0x000002C4	CREGISTER=18
+	PWMSS1			: org = 0x48302000 len = 0x000002C4	CREGISTER=19
+	PWMSS2			: org = 0x48304000 len = 0x000002C4	CREGISTER=20
+	GEMAC			: org = 0x4A100000 len = 0x0000128C	CREGISTER=9
+	I2C1			: org = 0x4802A000 len = 0x000000D8	CREGISTER=2
+	I2C2			: org = 0x4819C000 len = 0x000000D8	CREGISTER=17
+	MBX0			: org = 0x480C8000 len = 0x00000140	CREGISTER=22
+	MCASP0_DMA		: org = 0x46000000 len = 0x00000100	CREGISTER=8
+	MCSPI0			: org = 0x48030000 len = 0x000001A4	CREGISTER=6
+	MCSPI1			: org = 0x481A0000 len = 0x000001A4	CREGISTER=16
+	MMCHS0			: org = 0x48060000 len = 0x00000300	CREGISTER=5
+	SPINLOCK		: org = 0x480CA000 len = 0x00000880	CREGISTER=23
+	TPCC			: org = 0x49000000 len = 0x00001098	CREGISTER=29
+	UART1			: org = 0x48022000 len = 0x00000088	CREGISTER=11
+	UART2			: org = 0x48024000 len = 0x00000088	CREGISTER=12
+
+	RSVD10			: org = 0x48318000 len = 0x00000100	CREGISTER=10
+	RSVD13			: org = 0x48310000 len = 0x00000100	CREGISTER=13
+	RSVD21			: org = 0x00032400 len = 0x00000100	CREGISTER=21
+	RSVD27			: org = 0x00032000 len = 0x00000100	CREGISTER=27
+
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU_DMEM_0_1, PAGE 1
+	.bss		>  PRU_DMEM_0_1, PAGE 1
+	.cio		>  PRU_DMEM_0_1, PAGE 1
+	.data		>  PRU_DMEM_0_1, PAGE 1
+	.switch		>  PRU_DMEM_0_1, PAGE 1
+	.sysmem		>  PRU_DMEM_0_1, PAGE 1
+	.cinit		>  PRU_DMEM_0_1, PAGE 1
+	.rodata		>  PRU_DMEM_0_1, PAGE 1
+	.rofardata	>  PRU_DMEM_0_1, PAGE 1
+	.farbss		>  PRU_DMEM_0_1, PAGE 1
+	.fardata	>  PRU_DMEM_0_1, PAGE 1
+
+	.resource_table > PRU_DMEM_0_1, PAGE 1
+}

--- a/examples/firmware_examples/example3-pwm/Makefile
+++ b/examples/firmware_examples/example3-pwm/Makefile
@@ -1,0 +1,62 @@
+# 
+# Copyright (c) 2016 Zubeen Tolani <ZeekHuge - zeekhuge@gmail.com>
+# Copyright (c) 2017 Texas Instruments - Jason Kridner <jdk@ti.com>
+# 
+
+# TARGET must be defined as the file to be compiled without the .c.
+# PRUN must be defined as the PRU number (0 or 1) to compile for.
+
+# PRU_CGT environment variable points to the TI PRU compiler directory.
+# PRU_SUPPORT points to pru-software-support-package.
+# GEN_DIR points to where to put the generated files.
+PRU_CGT:=/usr/share/ti/cgt-pru
+PRU_SUPPORT:=/usr/lib/ti/pru-software-support-package
+GEN_DIR:=/tmp/pru$(PRUN)-gen
+
+LINKER_COMMAND_FILE=AM335x_PRU.cmd
+LIBS=--library=$(PRU_SUPPORT)/lib/rpmsg_lib.lib
+INCLUDE=--include_path=$(PRU_SUPPORT)/include --include_path=$(PRU_SUPPORT)/include/am335x
+
+STACK_SIZE=0x100
+HEAP_SIZE=0x100
+
+CFLAGS=-v3 -O2 --printf_support=minimal --display_error_number --endian=little --hardware_mac=on --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) --asm_directory=$(GEN_DIR) -ppd -ppa --asm_listing --c_src_interlist # --absolute_listing
+
+LFLAGS=--reread_libs --warn_sections --stack_size=$(STACK_SIZE) --heap_size=$(HEAP_SIZE) -m $(GEN_DIR)/$(TARGET).map
+
+# Lookup PRU by address
+ifeq ($(PRUN),0)
+PRU_ADDR=4a334000
+endif
+ifeq ($(PRUN),1)
+PRU_ADDR=4a338000
+endif
+
+PRU_DIR=$(wildcard /sys/devices/platform/ocp/4a32600*.pruss-soc-bus/4a300000.pruss/$(PRU_ADDR).*/remoteproc/remoteproc*)
+
+all: stop install start
+
+stop:
+	@echo "-    Stopping PRU $(PRUN)"
+	@echo stop | sudo tee $(PRU_DIR)/state || echo Cannot stop $(PRUN)
+
+start:
+	@echo "-    Starting PRU $(PRUN)"
+	@echo start | sudo tee $(PRU_DIR)/state
+
+install: $(GEN_DIR)/$(TARGET).out
+	@echo '-	copying firmware file $(GEN_DIR)/$(TARGET).out to /lib/firmware/am335x-pru$(PRUN)-fw'
+	@sudo cp $(GEN_DIR)/$(TARGET).out /lib/firmware/am335x-pru$(PRUN)-fw
+
+$(GEN_DIR)/$(TARGET).out: $(GEN_DIR)/$(TARGET).obj
+	@echo 'LD	$^' 
+	@lnkpru -i$(PRU_CGT)/lib -i$(PRU_CGT)/include $(LFLAGS) -o $@ $^ $(LINKER_COMMAND_FILE) --library=libc.a $(LIBS) $^
+
+$(GEN_DIR)/$(TARGET).obj: $(TARGET).c
+	@mkdir -p $(GEN_DIR)
+	@echo 'CC	$<'
+	@clpru --include_path=$(PRU_CGT)/include $(INCLUDE) $(CFLAGS) -D=PRUN=$(PRUN) -fe $@ $<
+
+clean:
+	@echo 'CLEAN	.    PRU $(PRUN)'
+	@rm -rf $(GEN_DIR)

--- a/examples/firmware_examples/example3-pwm/README.md
+++ b/examples/firmware_examples/example3-pwm/README.md
@@ -1,0 +1,9 @@
+# PWM Example
+
+This example generates a PWM output of a desired voltage at the pin P9_31.<br>
+`config-pin P9_31 pruout`<br>
+`disable_uboot_overlay_video=1` in `/boot/uEnv.txt`<br>
+`export PRUN=0`<br>
+`export TARGET=pwm_test`<br>
+`export PRU_CGT=/usr/share/ti/cgt-pru`<br>
+`make clean && make`

--- a/examples/firmware_examples/example3-pwm/pwm_test.c
+++ b/examples/firmware_examples/example3-pwm/pwm_test.c
@@ -1,0 +1,52 @@
+#include <stdint.h>
+#include <pru_cfg.h>
+#include "resource_table_empty.h"
+
+volatile register uint32_t __R30;
+volatile register uint32_t __R31;
+int i;
+
+void stall(int n){
+    for (i = 0; i < n; i++){
+        __delay_cycles(1);
+    }
+}
+
+int calcCycles_D(float d, int offCycles){
+    int cycles;
+    if (d < 1){
+        cycles = (int)((offCycles * d)/(1 - d));
+        return cycles;
+    }
+    else
+        return 0;
+}
+
+int calcCycles_V(float v, int offCycles){
+    float duty_cycle = v/3.14;
+    int cycles;
+    if(duty_cycle < 1)
+        cycles = calcCycles_D(duty_cycle, offCycles);
+    else 
+        return 0;
+    return cycles;
+}
+
+void main(void){
+    uint32_t gpio;
+
+    CT_CFG.SYSCFG_bit.STANDBY_INIT = 0;
+
+    gpio = 0x0001;
+
+    int offCycles = 10000; 
+    int onCycles = calcCycles_V(2, offCycles);
+
+    while(1){
+        __R30 |= gpio;
+        stall(onCycles);
+        __R30 &= ~gpio;
+        stall(offCycles);
+    }
+    
+}

--- a/examples/firmware_examples/example3-pwm/resource_table_empty.h
+++ b/examples/firmware_examples/example3-pwm/resource_table_empty.h
@@ -1,0 +1,39 @@
+/*
+ *  ======== resource_table_empty.h ========
+ *
+ *  Define the resource table entries for all PRU cores. This will be
+ *  incorporated into corresponding base images, and used by the remoteproc
+ *  on the host-side to allocated/reserve resources.  Note the remoteproc
+ *  driver requires that all PRU firmware be built with a resource table.
+ *
+ *  This file contains an empty resource table.  It can be used either as:
+ *
+ *        1) A template, or
+ *        2) As-is if a PRU application does not need to configure PRU_INTC
+ *                  or interact with the rpmsg driver
+ *
+ */
+
+#ifndef _RSC_TABLE_PRU_H_
+#define _RSC_TABLE_PRU_H_
+
+#include <stddef.h>
+#include <rsc_types.h>
+
+struct my_resource_table {
+	struct resource_table base;
+
+	uint32_t offset[1]; /* Should match 'num' in actual definition */
+};
+
+#pragma DATA_SECTION(pru_remoteproc_ResourceTable, ".resource_table")
+#pragma RETAIN(pru_remoteproc_ResourceTable)
+struct my_resource_table pru_remoteproc_ResourceTable = {
+	1,	/* we're the first version that implements this */
+	0,	/* number of entries in the table */
+	0, 0,	/* reserved, must be zero */
+	0,	/* offset[0] */
+};
+
+#endif /* _RSC_TABLE_PRU_H_ */
+


### PR DESCRIPTION
A test example added for PWM on the pin P9_31.
Need to add userspace program to control voltage from user space (by writing to pru memory).