### PR TITLE
Fix syntax error in prussd.py; take 4-byte input data for pwm

### DIFF
--- a/examples/firmware_examples/example3-pwm/pwm-assembly/main_pru1.c
+++ b/examples/firmware_examples/example3-pwm/pwm-assembly/main_pru1.c
@@ -2,8 +2,14 @@
 #include <pru_cfg.h>
 #include "resource_table_empty.h"
 
+#define PRU_SHARED 0x00010000
+
 extern void start(void);
 
 void main(void){
+ //   CT_CFG.SYSCFG_bit.STANDBY_INIT = 0;
+
+    //volatile int* buffer = (volatile int *) PRU_SHARED;
+
     start();
 }

--- a/examples/firmware_examples/example3-pwm/pwm-assembly/pru-asm-pwm.asm
+++ b/examples/firmware_examples/example3-pwm/pwm-assembly/pru-asm-pwm.asm
@@ -1,33 +1,36 @@
 ;* Source written by Pratim Ugale <pratim.ugale@gmail.com>
-;* This is a PWM example 
-;* Observation: When 
+;* This example generates a PWM signal and is capable of producing frequencies from 1 Hz to 1 MHz
+;* The 8 byte ON_Cycles input must be in memory location 0x00010000 - 0x00010003 in backwards byte-wise order
+;* The 8 byte Total_Cycles input must be in memory location 0x00010005 - 0x00010008 in backwards byte-wise order
 
-	.cdecls "main_pru1.c"
+	.cdecls "main_pwm.c"
 
-PRU_SRAM .set 0x00010000
+PRU_SRAM .set 0x00010000            ; Set the location of PRU Shared Memory
 
 	.clink
 	.global start
-start:  
-        LDI32   R10, PRU_SRAM       ; R10-> Base address of PRU SRAM
-        LBBO    &R1.b0, R10, 0, 1   ; R1 -> Duty Cycle. Copy (1) bytes into R1 from memory address R10+offset(0)
-        LBBO    &R2.b0, R10, 1, 1   ; R2 -> . Copy (1) bytes into R1 from memory address R10+offset(0)
-        LDI     R0, 0               ; R0 - Total sample count (goes from 0 to 100)
+start:                              ; One time setup.
+        LDI32   R10, PRU_SRAM       ; R10 -> Base address of PRU SRAM
+        SUB     R1, R1, R1          ; Clear the contents of R1
+        SUB     R2, R2, R2          ; Clear the contents of R2
+        LBBO    &R1, R10, 0, 4      ; R1 -> Duty Cycle.(actually ON cycles); Copy (4) bytes into R1 from memory address R10+offset(0)
+        LBBO    &R2, R10, 5, 4      ; R2 -> Total Cycles. Copy (4) bytes into R2 from memory address R10+offset(5)
+        LDI     R0, 0               ; R0 - Total sample count (goes from 0 to 100 for 1MHz)
         QBA     sample_start
 
-sample_start:                       ; [1 cycle]
-        SET     R30, R30.t0         ; GPIO ON
-sample_high:                        
-        ADD     R0, R0, 1           ; Increment counter by 1 
-        QBNE    sample_high, R0.b0, R1.b0
+sample_start:                       ; 
+        SET     R30, R30.t0         ; GPIO P9_31 ON
+sample_high:                        ; [Loop consuming 2 PRU cycles per iteration]
+        ADD     R0, R0, 0x00000001  ; Increment counter by 1 
+        QBNE    sample_high, R0, R1 ; Repeat loop until ON_Cycles 
         NOP
         NOP
         NOP
-        CLR     R30, R30.t0
-sample_low:
-        ADD     R0, R0, 1
-        QBNE    sample_low, R0.b0, R2.b0
-        SUB     R0, R0, R0
-        QBA     sample_start
+        CLR     R30, R30.t0         ; GPIO P9_31 OFF
+sample_low:                         ; [Loop consuming 2 PRU cycles per iteration]
+        ADD     R0, R0, 0x00000001  ; Increment counter by 1
+        QBNE    sample_low, R0, R2  ; Repeat loop until Total Cycles
+        SUB     R0, R0, R0          ; Clear the counter register
+        QBA     sample_start        ; One PWM cycle is completed. Repeat again for back to back pulses.
 
 	HALT

--- a/prussd/prussd.py
+++ b/prussd/prussd.py
@@ -285,7 +285,7 @@ class PRURequestHandler(socketserver.StreamRequestHandler):
             "LOAD_1": lambda: load_firmware(1, cmd),
             "GETMSG": lambda: get_msg(cmd),
             "SENDMSG": lambda: send_msg(cmd),
-            "EVENTWAIT": lambda: event_wait(cmd)
+            "EVENTWAIT": lambda: event_wait(cmd),
             "MEMWRITE_D0": lambda: mem_write(0, cmd),
             "MEMWRITE_D1": lambda: mem_write(1, cmd),
             "MEMWRITE_S": lambda: mem_write(3, cmd),


### PR DESCRIPTION
I have made a mistake with the commit-name: 
There should ideally be 2 commits in this PR: one for daemon error and one for PWM update
Changes made: 
1. PWM example made to take in 4 bytes of data so that frequency of PWM can be adjusted by increasing number of iterations. 
2. `prussd.py`: Removed a syntax error that put the prussd.service in a failed state while installing. The error is mentioned here: https://pastebin.com/mAZASD0t. I SHOULD NOT HAVE PUT THIS CHANGE IN THE SAME COMMIT