### PR TITLE
Strobe Stepper Motor Interrupt from main_pru0.c instead of pulse-supply.asm

### DIFF
--- a/examples/firmware_examples/example7-stepper-control/PRU0/main_pru0.c
+++ b/examples/firmware_examples/example7-stepper-control/PRU0/main_pru0.c
@@ -38,15 +38,15 @@ void configIntc(void)
 
 void main(void){
 
+    // Configure GPI and GPO as Mode0 - Direct Connect
+    CT_CFG.GPCFG0 = 0x0000;
+
     configIntc();
 
     start();
     // All Pulses have now been sent
     
     PRU0_PRU1_TRIGGER;
-    
-    // Configure GPI and GPO as Mode0 - Direct Connect
-    //CT_CFG.GPCFG0 = 0x0000;
 
     __halt();
 }

--- a/examples/firmware_examples/example7-stepper-control/README.md
+++ b/examples/firmware_examples/example7-stepper-control/README.md
@@ -1,5 +1,8 @@
 # Stepper Motor Control
 
+Video of working: [https://www.youtube.com/watch?v=joPQ1JjVkvU](https://www.youtube.com/watch?v=joPQ1JjVkvU)
+Will add a demonstration video soon.
+
 ## Hardware Used
 
 1. Motor: [NEMA 17 Motor]()

--- a/examples/firmware_examples/example7-stepper-control/driver_lib.cpp
+++ b/examples/firmware_examples/example7-stepper-control/driver_lib.cpp
@@ -9,6 +9,8 @@ Driver& Driver::get(){
     return driver;
 }
 
+int Driver::i = 0;
+
 Driver::Driver(){
     // Set default stepmode to:     eighth step mode - One rotation is 1600 steps
     //                              quarter step mode- One rotation is 800  steps
@@ -18,6 +20,8 @@ Driver::Driver(){
 
     // Set default direction to clockwise.
     setDirection(CLOCKWISE);
+
+    // Command counter
 }
 
 void Driver::setStepMode(StepMode stepMode){
@@ -162,12 +166,11 @@ int Driver::activateMotor(float degrees, float rpm, StepMode stepMode, Direction
     // Wait for event on RPMsg channel, to ensure that multiple commands aren't sent to the driver/motor simultaneously.
     // PRU1 sends back "done\n" on RPMsg channel, once PRU0 interrupts it after it is done sending all its pulses.
     string messageFromPRU;
-    int i = 0;
     while(1){
         messageFromPRU = this->p1.getMsg();
         if(messageFromPRU.compare(EXPECTED_MESSAGE) == 0){
-            i++;
-            cout<<"Motor Command "<<i<<" Completed"<<endl;
+            Driver::i++;
+            cout<<"Motor Command "<<Driver::i<<" Completed"<<endl;
             break;
         }
         

--- a/examples/firmware_examples/example7-stepper-control/driver_lib.h
+++ b/examples/firmware_examples/example7-stepper-control/driver_lib.h
@@ -61,6 +61,7 @@ class Driver{
         ~Driver();
 
         static Driver& get();
+        static int i; // gets 0 initialized
 };
 
 #endif


### PR DESCRIPTION
The interrupt from PRU0 to PRU1 is now triggered by main_pru0.c <br>
Registers being used by pulse-supply.asm changed so that the compiler can use its required ones.
Small bug: variable 'i' which counts the motor commands should have been static.