### PR TITLE
Add Example 8 to demonstrate calling and linking multiple .asm files from the c-firmware

### DIFF
--- a/examples/firmware_examples/example8-multiple-assembly-calls/Makefile
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/Makefile
@@ -1,0 +1,28 @@
+.PHONY: all install userspace
+
+all: clean install userspace
+
+install: 
+	@config-pin P9-31 pruout
+	@config-pin P9-30 pruout
+	@config-pin P9-29 pruout
+	@echo '------------------------------------------------------------------------- '
+	@echo 'Compiling and Loading Firmware For PRU0'
+	@cd ./PRU0/ && make
+	@cd ./PRU0/ && sudo make install
+	@echo '------------------------------------------------------------------------- '
+	@echo '------------------------------------------------------------------------- '
+
+userspace:
+	@echo 'Compiling the UserSpace Program'
+	@g++ user_test.cpp ../../../cpp-bindings/pruss.cpp -o userspace.o
+	@echo '------------------------------------------------------------------------- '
+	@echo 'Running the UserSpace Program'
+	@./userspace.o
+	@echo '------------------------------------------------------------------------- '
+	@echo 'Execution Complete'
+	@echo '------------------------------------------------------------------------- '
+
+.PHONY: clean
+clean:
+	@cd ./PRU0/ && make clean

--- a/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/AM335x_PRU.cmd
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/AM335x_PRU.cmd
@@ -1,0 +1,86 @@
+/****************************************************************************/
+/*  AM335x_PRU.cmd                                                          */
+/*  Copyright (c) 2015  Texas Instruments Incorporated                      */
+/*                                                                          */
+/*    Description: This file is a linker command file that can be used for  */
+/*                 linking PRU programs built with the C compiler and       */
+/*                 the resulting .out file on an AM335x device.             */
+/****************************************************************************/
+
+-cr								/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	PRU_IMEM		: org = 0x00000000 len = 0x00002000  /* 8kB PRU0 Instruction RAM */
+
+      PAGE 1:
+
+	/* RAM */
+
+	PRU_DMEM_0_1	: org = 0x00000000 len = 0x00002000 CREGISTER=24 /* 8kB PRU Data RAM 0_1 */
+	PRU_DMEM_1_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25 /* 8kB PRU Data RAM 1_0 */
+
+	  PAGE 2:
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00003000 CREGISTER=28 /* 12kB Shared RAM */
+
+	DDR			    : org = 0x80000000 len = 0x00000100	CREGISTER=31
+	L3OCMC			: org = 0x40000000 len = 0x00010000	CREGISTER=30
+
+
+	/* Peripherals */
+
+	PRU_CFG			: org = 0x00026000 len = 0x00000044	CREGISTER=4
+	PRU_ECAP		: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_IEP			: org = 0x0002E000 len = 0x0000031C	CREGISTER=26
+	PRU_INTC		: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_UART		: org = 0x00028000 len = 0x00000038	CREGISTER=7
+
+	DCAN0			: org = 0x481CC000 len = 0x000001E8	CREGISTER=14
+	DCAN1			: org = 0x481D0000 len = 0x000001E8	CREGISTER=15
+	DMTIMER2		: org = 0x48040000 len = 0x0000005C	CREGISTER=1
+	PWMSS0			: org = 0x48300000 len = 0x000002C4	CREGISTER=18
+	PWMSS1			: org = 0x48302000 len = 0x000002C4	CREGISTER=19
+	PWMSS2			: org = 0x48304000 len = 0x000002C4	CREGISTER=20
+	GEMAC			: org = 0x4A100000 len = 0x0000128C	CREGISTER=9
+	I2C1			: org = 0x4802A000 len = 0x000000D8	CREGISTER=2
+	I2C2			: org = 0x4819C000 len = 0x000000D8	CREGISTER=17
+	MBX0			: org = 0x480C8000 len = 0x00000140	CREGISTER=22
+	MCASP0_DMA		: org = 0x46000000 len = 0x00000100	CREGISTER=8
+	MCSPI0			: org = 0x48030000 len = 0x000001A4	CREGISTER=6
+	MCSPI1			: org = 0x481A0000 len = 0x000001A4	CREGISTER=16
+	MMCHS0			: org = 0x48060000 len = 0x00000300	CREGISTER=5
+	SPINLOCK		: org = 0x480CA000 len = 0x00000880	CREGISTER=23
+	TPCC			: org = 0x49000000 len = 0x00001098	CREGISTER=29
+	UART1			: org = 0x48022000 len = 0x00000088	CREGISTER=11
+	UART2			: org = 0x48024000 len = 0x00000088	CREGISTER=12
+
+	RSVD10			: org = 0x48318000 len = 0x00000100	CREGISTER=10
+	RSVD13			: org = 0x48310000 len = 0x00000100	CREGISTER=13
+	RSVD21			: org = 0x00032400 len = 0x00000100	CREGISTER=21
+	RSVD27			: org = 0x00032000 len = 0x00000100	CREGISTER=27
+
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU_DMEM_0_1, PAGE 1
+	.bss		>  PRU_DMEM_0_1, PAGE 1
+	.cio		>  PRU_DMEM_0_1, PAGE 1
+	.data		>  PRU_DMEM_0_1, PAGE 1
+	.switch		>  PRU_DMEM_0_1, PAGE 1
+	.sysmem		>  PRU_DMEM_0_1, PAGE 1
+	.cinit		>  PRU_DMEM_0_1, PAGE 1
+	.rodata		>  PRU_DMEM_0_1, PAGE 1
+	.rofardata	>  PRU_DMEM_0_1, PAGE 1
+	.farbss		>  PRU_DMEM_0_1, PAGE 1
+	.fardata	>  PRU_DMEM_0_1, PAGE 1
+
+	.resource_table > PRU_DMEM_0_1, PAGE 1
+}

--- a/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/Makefile
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/Makefile
@@ -1,0 +1,112 @@
+# Copyright (c) 2016 Zubeen Tolani <ZeekHuge - zeekhuge@gmail.com>
+#
+# Usage:
+#	Main source file: pru0.c
+# 	add targets to variable TARGETS
+#	add other files required while linking in variable LINK_PRU1(0)_FW
+#	add compile targets, as added to LINK_PRU1(0)_FW for other files.
+# 
+
+# PRU_CGT environment variable points to the TI PRU compiler directory. (Usually /usr/share/ti/cgt-pru)
+PRU_CGT:=/usr/share/ti/cgt-pru
+
+
+############################################################
+ifndef PRU_CGT
+define ERROR_BODY
+
+************************************************************
+PRU_CGT environment variable is not set. Examples given:
+(Linux) export PRU_CGT=/home/jason/ti/ccs_v6_1_0/ccsv6/tools/compiler/ti-cgt-pru_2.1.0
+(Windows) set PRU_CGT=C:/TI/ccs_v6_0_1/ccsv6/tools/compiler/ti-cgt-pru_2.1.0
+************************************************************
+
+endef
+$(error $(ERROR_BODY))
+endif
+
+PRU_SUPPORT:=/usr/lib/ti/pru-software-support-package
+############################################################
+
+############################################################
+LINKER_COMMAND_FILE=./AM335x_PRU.cmd
+LIBS=--library=$(PRU_SUPPORT)/lib/rpmsg_lib.lib
+INCLUDE=--include_path=$(PRU_SUPPORT)/include --include_path=$(PRU_SUPPORT)/include/am335x
+STACK_SIZE=0x100
+HEAP_SIZE=0x100
+
+
+CFLAGS=-v3 -O2 --printf_support=minimal --display_error_number --endian=little --hardware_mac=on --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) --asm_directory=$(GEN_DIR) -ppd -ppa --asm_listing --optimizer_interlist --c_src_interlist # --absolute_listing
+LFLAGS=--reread_libs --warn_sections --stack_size=$(STACK_SIZE) --heap_size=$(HEAP_SIZE) -m $(GEN_DIR)/$(TARGET).map
+############################################################
+
+############################################################
+GEN_DIR=gen
+
+PRU0_FW		=$(GEN_DIR)/pru0_fw.out
+
+# add the required firmwares to TARGETS
+TARGETS		=$(PRU0_FW)
+
+# required linking files for PRU0
+LINK_PRU0_FW1= $(GEN_DIR)/assembly1.object
+LINK_PRU0_FW2= $(GEN_DIR)/assembly2.object
+LINK_PRU0_FW3= $(GEN_DIR)/assembly3.object
+# Link to .object dependencies on line 66. Add 4th link here.
+
+############################################################
+
+
+
+.PHONY: all
+all: $(TARGETS) 
+	@echo '-	Generated firmwares are : $^'
+
+# Linking together all the .object file made by clpru
+$(PRU0_FW): $(GEN_DIR)/main_pru0.object $(LINK_PRU0_FW1) $(LINK_PRU0_FW2) $(LINK_PRU0_FW3)
+	@echo 'LD	$^' 
+	@$(PRU_CGT)/bin/lnkpru -i$(PRU_CGT)/lib -i$(PRU_CGT)/include $(LFLAGS) -o $@ $^  $(LINKER_COMMAND_FILE) --library=libc.a $(LIBS) $^
+
+
+$(GEN_DIR)/main_pru0.object: pru0.c 
+	@mkdir -p $(GEN_DIR)
+	@echo 'CC	$<'
+	@$(PRU_CGT)/bin/clpru --include_path=$(PRU_CGT)/include $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+$(GEN_DIR)/assembly1.object: assembly1.asm
+	@mkdir -p $(GEN_DIR)
+	@echo 'CC	$<'
+	@$(PRU_CGT)/bin/clpru --include_path=$(PRU_CGT)/include $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+$(GEN_DIR)/assembly2.object: assembly2.asm
+	@mkdir -p $(GEN_DIR)
+	@echo 'CC	$<'
+	@$(PRU_CGT)/bin/clpru --include_path=$(PRU_CGT)/include $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+$(GEN_DIR)/assembly3.object: assembly3.asm
+	@mkdir -p $(GEN_DIR)
+	@echo 'CC	$<'
+	@$(PRU_CGT)/bin/clpru --include_path=$(PRU_CGT)/include $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+############################################################
+# Add 4th assembly object target here:
+#$(GEN_DIR)/assembly4.object: assembly4.asm
+#	@mkdir -p $(GEN_DIR)
+#	@echo 'CC	$<'
+#	@$(PRU_CGT)/bin/clpru --include_path=$(PRU_CGT)/include $(INCLUDE) $(CFLAGS) -fe $@ $<
+############################################################
+
+.PHONY: install install-pru0 copy_pru0_fw  
+
+install: $(patsubst $(GEN_DIR)/pru%_fw.out, install-pru%, $(TARGETS))
+
+install-pru0: $(PRU0_FW) copy_pru0_fw 
+
+copy_pru0_fw: $(PRU0_FW)
+	@echo '-	copying firmware to /lib/firmware/am335x_pru0_fw'
+	@cp $(PRU0_FW) /lib/firmware/am335x-pru0-fw
+
+.PHONY: clean
+clean:
+	@echo 'CLEAN	.'
+	@rm -rf $(GEN_DIR)

--- a/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/assembly1.asm
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/assembly1.asm
@@ -1,0 +1,18 @@
+;* Source written by Pratim Ugale <pratim.ugale@gmail.com>
+;* This example is used to control a stepper motor by sending out precise number of pulse trains at required frequency(RPM). 
+;* The 4 byte ON_Cycles input must be in memory location 0x00010000 - 0x00010003 in little-endian byte order
+;* The 4 byte Total_Cycles input must be in memory location 0x00010004 - 0x00010007 in little endian byte order
+;* The 4 byte Number of Pulses input must be in memory location 0x00010008 - 0x000100011 in little-endian byte order
+
+	.cdecls "pru0.c"
+
+PRU_SRAM .set 0x00010000            ; Set the location of PRU Shared Memory
+
+	.clink
+	.global start1
+start1:                                  ; One time setup.
+        SET      R30, R30.t1
+
+stop:
+        ;SET     R31, R31.t5            ; Strobe interrupt configured in main_pru0.c by setting bit 5 of R31 to HIGH
+        JMP      R3.w2                  ; R3.w2 -> stores the return address. The main_pru0.c program will continue its normal execution after start().

--- a/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/assembly2.asm
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/assembly2.asm
@@ -1,0 +1,17 @@
+;* Source written by Pratim Ugale <pratim.ugale@gmail.com>
+;* This example is used to control a stepper motor by sending out precise number of pulse trains at required frequency(RPM). 
+;* The 4 byte ON_Cycles input must be in memory location 0x00010000 - 0x00010003 in little-endian byte order
+;* The 4 byte Total_Cycles input must be in memory location 0x00010004 - 0x00010007 in little endian byte order
+;* The 4 byte Number of Pulses input must be in memory location 0x00010008 - 0x000100011 in little-endian byte order
+
+	.cdecls "pru0.c"
+
+PRU_SRAM .set 0x00010000            ; Set the location of PRU Shared Memory
+
+	.clink
+	.global start2
+start2:                                  ; One time setup.
+        SET      R30, R30.t0
+stop:
+        ;SET     R31, R31.t5            ; Strobe interrupt configured in main_pru0.c by setting bit 5 of R31 to HIGH
+        JMP      R3.w2                  ; R3.w2 -> stores the return address. The main_pru0.c program will continue its normal execution after start().

--- a/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/assembly3.asm
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/assembly3.asm
@@ -1,0 +1,17 @@
+;* Source written by Pratim Ugale <pratim.ugale@gmail.com>
+;* This example is used to control a stepper motor by sending out precise number of pulse trains at required frequency(RPM). 
+;* The 4 byte ON_Cycles input must be in memory location 0x00010000 - 0x00010003 in little-endian byte order
+;* The 4 byte Total_Cycles input must be in memory location 0x00010004 - 0x00010007 in little endian byte order
+;* The 4 byte Number of Pulses input must be in memory location 0x00010008 - 0x000100011 in little-endian byte order
+
+	.cdecls "pru0.c"
+
+PRU_SRAM .set 0x00010000            ; Set the location of PRU Shared Memory
+
+	.clink
+	.global start3
+start3:                                  ; One time setup.
+        SET      R30, R30.t2
+stop:
+        ;SET     R31, R31.t5            ; Strobe interrupt configured in main_pru0.c by setting bit 5 of R31 to HIGH
+        JMP      R3.w2                  ; R3.w2 -> stores the return address. The main_pru0.c program will continue its normal execution after start().

--- a/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/pru0.c
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/pru0.c
@@ -1,0 +1,56 @@
+#include <stdint.h>
+#include <pru_cfg.h>
+#include <pru_intc.h>               // Interrupt Controller
+#include "resource_table_empty.h"   // Resource  Table
+
+#define PRU_SHARED 0x00010000       // PRU Shared Memory Address
+
+volatile register uint32_t __R31;   // Directly access R31 to generate interrupts
+
+#define PRU0_PRU1_EVT       (16)    // Defining PRU0 to PRU 1 Interrupt
+#define PRU0_PRU1_TRIGGER   (__R31 = (PRU0_PRU1_EVT - 16) | (1 << 5))
+
+extern void start1(void);
+extern void start2(void);
+extern void start3(void);
+
+/* INTC configuration
+ * We are going to map User event 16 to Host 0
+ * PRU1 will then wait for r31 bit 30 (designates Host 0) to go high
+ * */
+
+void configIntc(void)
+{
+	/* Clear any pending PRU-generated events */
+	__R31 = 0x00000000;
+	/* Map event 16 to channel 0 */
+	CT_INTC.CMR4_bit.CH_MAP_16 = 0; 
+	/* Map channel 0 to host 0 */
+	CT_INTC.HMR0_bit.HINT_MAP_0 = 0; 
+	/* Ensure event 16 is cleared */
+	CT_INTC.SICR = 16; 
+	/* Enable event 16 */
+	CT_INTC.EISR = 16; 
+	/* Enable Host interrupt 1 */
+	CT_INTC.HIEISR |= (0 << 0); 
+// DON'T DO ->        __R31 |= ((uint32_t) 1 << 30);
+	// Globally enable host interrupts
+	CT_INTC.GER = 1; 
+}
+
+void main(void){
+
+    // Configure GPI and GPO as Mode0 - Direct Connect
+    CT_CFG.GPCFG0 = 0x0000;
+
+    configIntc();
+
+    start1();
+    start2();
+    start3();
+    // All Pulses have now been sent
+    
+    PRU0_PRU1_TRIGGER;
+
+    __halt();
+}

--- a/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/resource_table_empty.h
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/PRU0/resource_table_empty.h
@@ -1,0 +1,39 @@
+/*
+ *  ======== resource_table_empty.h ========
+ *
+ *  Define the resource table entries for all PRU cores. This will be
+ *  incorporated into corresponding base images, and used by the remoteproc
+ *  on the host-side to allocated/reserve resources.  Note the remoteproc
+ *  driver requires that all PRU firmware be built with a resource table.
+ *
+ *  This file contains an empty resource table.  It can be used either as:
+ *
+ *        1) A template, or
+ *        2) As-is if a PRU application does not need to configure PRU_INTC
+ *                  or interact with the rpmsg driver
+ *
+ */
+
+#ifndef _RSC_TABLE_PRU_H_
+#define _RSC_TABLE_PRU_H_
+
+#include <stddef.h>
+#include <rsc_types.h>
+
+struct my_resource_table {
+	struct resource_table base;
+
+	uint32_t offset[1]; /* Should match 'num' in actual definition */
+};
+
+#pragma DATA_SECTION(pru_remoteproc_ResourceTable, ".resource_table")
+#pragma RETAIN(pru_remoteproc_ResourceTable)
+struct my_resource_table pru_remoteproc_ResourceTable = {
+	1,	/* we're the first version that implements this */
+	0,	/* number of entries in the table */
+	0, 0,	/* reserved, must be zero */
+	0,	/* offset[0] */
+};
+
+#endif /* _RSC_TABLE_PRU_H_ */
+

--- a/examples/firmware_examples/example8-multiple-assembly-calls/README.md
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/README.md
@@ -1,0 +1,10 @@
+# Calling multiple .asm files from C-program
+
+## Some background details:
+
+1. The `clpru` compiler uses C/C++ code to generate assembly language code.
+2. The assembler built into `clpru` translates assembly language code into machine object (.object) files.
+3. The `lnkpru` linker combines the object files into a single executable object file (.out). 
+4. The generated `.out` file can be executed directly on a PRU device. To do so on a BB, it must be renamed to `am335x-pru0-fw` or `am335x-pru1-fw` and placed in the `/lib/firmware` directory. 
+5. On starting the PRU, it will be loaded with the respective firmware in this `/lib/firmware` directory.
+

--- a/examples/firmware_examples/example8-multiple-assembly-calls/user_test.cpp
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/user_test.cpp
@@ -1,0 +1,13 @@
+#include "../../../cpp-bindings/pruss.h"
+
+using namespace std;
+
+int main(){
+    PRUSS& p = PRUSS::get();
+    
+    PRU p0 = p.pru0;
+
+    p0.enable();
+
+    return 0;
+}


### PR DESCRIPTION
A simple example to demonstrate the use of multiple .asm files with the c-program.
clpru creates .object files for all the assembly and c files.
lnkpru properly links all .object files to the .out file which is loaded to the PRU