### PR TITLE
Fix Bug in mem_read(), mem_write() functions 

### DIFF
--- a/examples/firmware_examples/example4-analog-wave-gen/PRU0/main_pru0.c
+++ b/examples/firmware_examples/example4-analog-wave-gen/PRU0/main_pru0.c
@@ -5,8 +5,8 @@
 
 #define PRU_SHARED 0x00010000
 
-static void *pruSharedMemory;
-static unsigned int *pruSharedMemory_int;
+static void* pruSharedMemory;
+static uint8_t* pruSharedMemory_int;
 
 extern void start(void);
 
@@ -14,25 +14,26 @@ void main(void){
     // Generate sine values in an array     
     
     int i;
-    unsigned int waveform[100]; 
+    uint8_t waveform[100]; 
     float gain = 50.0f;
     float phase = 0.0f;
     float bias = 50.0f;
     float freq = 2.0f * 3.14159f / 100.0f;
     
     for (i = 0; i < 100; i++){
-        waveform[i] = (unsigned int)(bias + (gain * sin((i*freq) + phase)));
+        waveform[i] = (uint8_t)(bias + (gain * sin((i*freq) + phase)));
+        //waveform[i] = (uint8_t)i;
     }
     
     //uint16_t* sram_pointer = (uint16_t *) PRU_SHARED;
     pruSharedMemory = (void *) PRU_SHARED;
 
-    pruSharedMemory_int = (unsigned int *)pruSharedMemory;
+    pruSharedMemory_int = (uint8_t *)pruSharedMemory;
 
-    unsigned int samplestep = 1;    //delay factor
+    uint8_t samplestep = 1;    //delay factor
     *(pruSharedMemory_int) = samplestep;
 
-    unsigned int numbersamples = 100;
+    uint8_t numbersamples = 100;
     *(pruSharedMemory_int+1) = numbersamples;
 
     for(i = 0; i < 100; i++){

--- a/examples/firmware_examples/example6-memory-debug/mem_read_write.cpp
+++ b/examples/firmware_examples/example6-memory-debug/mem_read_write.cpp
@@ -15,6 +15,17 @@ int main()
         // Choose which memory access is needed - read the enum from pruss.h
         Memory mem = SHARED;
 
+        // Start
+        
+        char off[4];
+        for(int i = 0; i < 100; i++){
+            sprintf(off, "%i", i); 
+            cout<<p0.mem_read(mem, off)<<endl;
+        }
+
+
+        // END
+
         cout<<"Choose Base Location:"<<endl;
         cout<<"1: DRAM0; 2: DRAM1; 3: SRAM"<<endl;
 

--- a/examples/firmware_examples/example8-multiple-assembly-calls/Makefile
+++ b/examples/firmware_examples/example8-multiple-assembly-calls/Makefile
@@ -1,21 +1,26 @@
+GEN := /gen
+TARGET := userspace
+
 .PHONY: all install userspace
 
-all: clean install userspace
+CXX := /usr/bin/g++
+
+all: clean install $(GEN)/$(TARGET).o
 
 install: 
 	@config-pin P9-31 pruout
 	@config-pin P9-30 pruout
 	@config-pin P9-29 pruout
+	@mkdir gen
 	@echo '------------------------------------------------------------------------- '
 	@echo 'Compiling and Loading Firmware For PRU0'
 	@cd ./PRU0/ && make
 	@cd ./PRU0/ && sudo make install
 	@echo '------------------------------------------------------------------------- '
-	@echo '------------------------------------------------------------------------- '
 
-userspace:
-	@echo 'Compiling the UserSpace Program'
-	@g++ user_test.cpp ../../../cpp-bindings/pruss.cpp -o userspace.o
+$(GEN)/$(TARGET).o: user_test.cpp
+	#@echo 'CC   $< '
+	@$(CXX) -o $@ ../../../cpp-bindings/pruss.cpp
 	@echo '------------------------------------------------------------------------- '
 	@echo 'Running the UserSpace Program'
 	@./userspace.o

--- a/prussd/prussd.py
+++ b/prussd/prussd.py
@@ -216,7 +216,7 @@ def event_wait(cmd):
 
 def mem_read(ram, cmd):
     try:
-        addr_offset = int(cmd[1], 16)
+        addr_offset = int(cmd[1], 10)
     except ValueError:
         return -errno.EINVAL
 
@@ -238,7 +238,7 @@ def mem_read(ram, cmd):
 
 def mem_write():
     try:
-        addr_offset = int(cmd[1], 16)
+        addr_offset = int(cmd[1], 10)
         data = int(cmd[2], 16)
     except ValueError:
         return -errno.EINVAL


### PR DESCRIPTION
1. Waveform generated but with some distortion in the end. There was a bug which disrupted debugging: 
2. Address offsets were being converted to hexadecimal values: 
    Resulted in skipping of some values
    for eg. after 09, 10 translated to 0x10 = 16 i.e. directly offset 16 was read hence skipping offsets: 10, 11, 12, 13, 14, 15.