### PR TITLE
Solve bugs in showRegs(), load_firmware() functions 

### DIFF
--- a/cpp-bindings/pruss.cpp
+++ b/cpp-bindings/pruss.cpp
@@ -1,4 +1,5 @@
 #include "pruss.h"
+#include <iostream>
 
 using namespace std;
 
@@ -33,7 +34,7 @@ string Socket::sendcmd(string command)
 	
 	int nbytes;
 	string received;
-	char buf[1024], rec[1024]; //buffers to store command and reply
+	char buf[2048], rec[2048]; //buffers to store command and reply
 	nbytes = snprintf(buf, sizeof(buf), command.c_str()); //store command in buf
 	buf[nbytes] = '\n';
 	send(this->fd, buf, strlen(buf), 0); // send command over the socket connection

--- a/prussd/prussd.py
+++ b/prussd/prussd.py
@@ -114,9 +114,6 @@ def load_firmware(number, cmd):
     if not os.path.exists(cmd[1]):
         return -errno.ENOENT
 
-    if not any(cmd[1].startswith(path) for path in paths.FIRMWARE_PATHS):
-        return -errno.EPERM
-
     try:
         fname = cmd[1].split("/")[-1]
         fw_path = paths.FIRMWARE_PATH+"/"+fname


### PR DESCRIPTION
The showRegs() function required more than 1kB of data transfer through /tmp/prussd.sock, increased to 2kB.
prussd.py: load() function was not working, solved